### PR TITLE
Search for .git instead of __init__.py

### DIFF
--- a/lsp-python.el
+++ b/lsp-python.el
@@ -17,7 +17,7 @@
 						 (directory-files
 						  dir
 						  nil
-						  "\\(__init__\\|setup\\)\\.py")))
+						  ".git\\|setup\\.py")))
 			 '("pyls"))
 
 (provide 'lsp-python)


### PR DESCRIPTION
`__init__.py` does not imply the root of a Python project, see: https://github.com/emacs-lsp/lsp-python/issues/5.