### PR TITLE
Correctly identify configuration files

### DIFF
--- a/lsp-python.el
+++ b/lsp-python.el
@@ -12,13 +12,20 @@
 (require 'lsp-mode)
 (require 'lsp-common)
 
-(lsp-define-stdio-client lsp-python "python"
-			 (lsp-make-traverser #'(lambda (dir)
-						 (directory-files
-						  dir
-						  nil
-              "setup.py\\|Pipfile\\|setup.cfg\\|tox.ini")))
-			 '("pyls"))
+(lsp-define-stdio-client
+ lsp-python
+ "python"
+ (lsp-make-traverser
+  #'(lambda (dir)
+      (directory-files
+       dir
+       nil
+       (regexp-opt
+        "setup.py"
+        "Pipfile"
+        "setup.cfg"
+        "tox.ini"))))
+ '("pyls"))
 
 (provide 'lsp-python)
 ;;; lsp-python.el ends here


### PR DESCRIPTION
`.` is special in regular expressions.  Use function `regexp-opt` to construct an appropriate pattern.  May fix some issues; I dunno.