### PR TITLE
Determine the project root using `__init__.py` files

### DIFF
--- a/lsp-python.el
+++ b/lsp-python.el
@@ -19,14 +19,29 @@
   :risky t
   :type '(repeat string))
 
+(defcustom lsp-python-use-init-for-project-root
+  nil
+  "Set to t to look for __init__.py files to determine a project's root.
+
+The first directory not containing an __init__.py file (looking
+upwards from the directory the open python file is in) is set as
+the project root for the lsp server.
+"
+  :group 'lsp-python
+  :type 'boolean)
+
 (defun lsp-python--ls-command ()
   "Generate the language server startup command."
   `("pyls" ,@lsp-python-server-args))
 
-(lsp-define-stdio-client lsp-python
-                         "python"
+(lsp-define-stdio-client lsp-python "python"
                          (lsp-make-traverser #'(lambda (dir)
-                                                 (not (directory-files dir nil "__init__.py"))))
+                                                 (if lsp-python-use-init-for-project-root
+                                                     (not (directory-files dir nil "__init__.py"))
+                                                   (directory-files
+                                                    dir
+                                                    nil
+                                                    "setup.py\\|Pipfile\\|setup.cfg\\|tox.ini"))))
                          nil
                          :command-fn 'lsp-python--ls-command)
 

--- a/lsp-python.el
+++ b/lsp-python.el
@@ -23,12 +23,10 @@
   "Generate the language server startup command."
   `("pyls" ,@lsp-python-server-args))
 
-(lsp-define-stdio-client lsp-python "python"
-			 (lsp-make-traverser #'(lambda (dir)
-						 (directory-files
-						  dir
-						  nil
-              "setup.py\\|Pipfile\\|setup.cfg\\|tox.ini")))
+(lsp-define-stdio-client lsp-python
+                         "python"
+                         (lsp-make-traverser #'(lambda (dir)
+                                                 (not (directory-files dir nil "__init__.py"))))
                          nil
                          :command-fn 'lsp-python--ls-command)
 


### PR DESCRIPTION
Instead of looking for an assortment of files that usually are located in the project root of a python project, we instead look for the first parent directory that does __not__ contain an `__init__.py` file.

This idea was formulated by [jamescasbon](https://github.com/jamescasbon) in [his comment](https://github.com/emacs-lsp/lsp-python/issues/5#issuecomment-382288916) on https://github.com/emacs-lsp/lsp-python/issues/5.  I have been using it for the last couple of months without any issues.  Apart from the simpler logic for finding the project root this also has the added advantage of correctly determining the project root for single file python scripts.