### PR TITLE
Change :get-root to nil

### DIFF
--- a/lsp-python.el
+++ b/lsp-python.el
@@ -34,15 +34,7 @@ the project root for the lsp server.
   "Generate the language server startup command."
   `("pyls" ,@lsp-python-server-args))
 
-(lsp-define-stdio-client lsp-python "python"
-                         (lsp-make-traverser #'(lambda (dir)
-                                                 (if lsp-python-use-init-for-project-root
-                                                     (not (directory-files dir nil "__init__.py"))
-                                                   (directory-files
-                                                    dir
-                                                    nil
-                                                    "setup.py\\|Pipfile\\|setup.cfg\\|tox.ini"))))
-                         nil
+(lsp-define-stdio-client lsp-python "python" nil nil
                          :command-fn 'lsp-python--ls-command)
 
 (provide 'lsp-python)


### PR DESCRIPTION
Since https://github.com/emacs-lsp/lsp-mode/pull/447
lsp--suggest-project-root (projectile or project.el) will be used instead to detect the root.
If the user has different preference for the project, read their documentation on how to override the default behavior.

If you have special needs for root detection, use projectile's mechanism, e.g.

* `.projectile` in your project
* `(push ".project" projectile-project-root-files-bottom-up)` then use `.project` in your project
* `(push "setup.py" projectile-project-root-files)` (used by `projectile-root-top-down`)
* etc